### PR TITLE
Fix mobile responsiveness for header and refund section

### DIFF
--- a/app/[searchParam]/SearchData.tsx
+++ b/app/[searchParam]/SearchData.tsx
@@ -234,38 +234,41 @@ export default function SearchData({ searchParam }: { searchParam: string }) {
                             <div className="items-center text-base mb-0.5 text-white w-full">
                                 <div className="mr-2 sm:text-xl text-base w-full">
                                     {swap.status == SwapStatus.Completed && output_transaction ?
-                                        <div className="flex flex-col sm:flex-row mb-4">
-                                            <div><StatusIcon swap={swap.status} />
-                                                <span className="text-secondary-300 mx-1">|</span>
-                                                <span className="whitespace-nowrap text-primary-text align-bottom">Date:</span>
-                                                <span className="whitespace-nowrap text-white align-bottom">&nbsp;
-                                                    <TooltipProvider delayDuration={0}>
-                                                        <Tooltip>
-                                                            <TooltipTrigger className="cursor-default">{new Date(input_transaction?.timestamp)?.toLocaleString('en-US', isCurrentYear ? optionsWithoutYear : optionsWithYear)}</TooltipTrigger>
-                                                            <TooltipContent>
-                                                                {new Date(swap.created_date).toUTCString()}
-                                                            </TooltipContent>
-                                                        </Tooltip>
-                                                    </TooltipProvider>
+                                        <div className="flex flex-col sm:flex-row sm:items-center flex-wrap gap-y-1 mb-4">
+                                            <StatusIcon swap={swap.status} />
+                                            <div className="flex items-center flex-wrap gap-x-2 sm:gap-x-0 gap-y-0.5">
+                                                <span className="whitespace-nowrap">
+                                                    <span className="text-secondary-300 mx-1 hidden sm:inline">|</span>
+                                                    <span className="text-primary-text align-bottom">Date:</span>
+                                                    <span className="text-white align-bottom ml-0.5">
+                                                        <TooltipProvider delayDuration={0}>
+                                                            <Tooltip>
+                                                                <TooltipTrigger className="cursor-default">{new Date(input_transaction?.timestamp)?.toLocaleString('en-US', isCurrentYear ? optionsWithoutYear : optionsWithYear)}</TooltipTrigger>
+                                                                <TooltipContent>
+                                                                    {new Date(swap.created_date).toUTCString()}
+                                                                </TooltipContent>
+                                                            </Tooltip>
+                                                        </TooltipProvider>
+                                                    </span>
+                                                </span>
+                                                <span className="whitespace-nowrap">
+                                                    <span className="text-secondary-300 mx-1 hidden sm:inline">|</span>
+                                                    <span className="text-primary-text">Duration:</span>
+                                                    <span className="text-white ml-0.5">{getTimeDifferenceFromNow(input_transaction?.timestamp, output_transaction?.timestamp)}</span>
+                                                </span>
+                                                <span className="whitespace-nowrap">
+                                                    <span className="text-secondary-300 mx-1 hidden sm:inline">|</span>
+                                                    <span className="text-primary-text">Cost:</span>
+                                                    <span className="text-white ml-0.5">{truncateDecimals(quote?.total_fee, sourceToken?.precision)} {swap?.source_token?.symbol}</span>
                                                 </span>
                                             </div>
-                                            <span className="text-secondary-300 mx-1">|</span>
-                                            <p className="sm:self-end">
-                                                <span className="sm:whitespace-nowrap sm:ml-0.5 text-primary-text">Duration:</span>
-                                                <span className="text-white">{getTimeDifferenceFromNow(input_transaction?.timestamp, output_transaction?.timestamp)}</span>
-                                            </p>
-                                            <span className="text-secondary-300 mx-1">|</span>
-                                            <p className="sm:self-end">
-                                                <span className="text-primary-text sm:ml-1">Cost:</span>
-                                                <span className="text-white">{truncateDecimals(quote?.total_fee, sourceToken?.precision)} {swap?.source_token?.symbol}</span>
-                                            </p>
                                         </div>
                                         :
                                         swap.status !== SwapStatus.Completed ?
-                                            <div className="flex flex-col sm:flex-row">
-                                                <div>
-                                                    <StatusIcon swap={swap.status} />
-                                                    <span className="text-secondary-300 mx-1">|</span>
+                                            <div className="flex flex-col sm:flex-row sm:items-center flex-wrap gap-y-1">
+                                                <StatusIcon swap={swap.status} />
+                                                <div className="flex items-center flex-wrap">
+                                                    <span className="text-secondary-300 mx-1 hidden sm:inline">|</span>
                                                     <span className="whitespace-nowrap text-primary-text align-bottom">Date:</span>
                                                     <span className="whitespace-nowrap text-white align-bottom">
                                                         <TooltipProvider delayDuration={0}>
@@ -277,11 +280,8 @@ export default function SearchData({ searchParam }: { searchParam: string }) {
                                                             </Tooltip>
                                                         </TooltipProvider>
                                                     </span>
+                                                    <span className="text-primary-text ml-1">({getTimeDifferenceFromNow(input_transaction?.timestamp, new Date().toString())} ago)</span>
                                                 </div>
-                                                <span className="text-secondary-300 mx-1">|</span>
-                                                <p className="sm:self-end">
-                                                    <span className="text-primary-text">({getTimeDifferenceFromNow(input_transaction?.timestamp, new Date().toString())} ago)</span>
-                                                </p>
                                             </div>
                                             :
                                             <div className="flex sm:flex-row"><StatusIcon swap={swap.status} />

--- a/components/RefundComp.tsx
+++ b/components/RefundComp.tsx
@@ -14,8 +14,8 @@ export default function Refund({ refund }: { refund: Transaction }) {
             <div className="flex items-center text-white">
                 <div className="mr-2 text-2xl font-medium">Refund</div>
             </div>
-            <div className="rounded-md w-full grid grid-cols-8 text-primary-text bg-secondary-700 shadow-lg relative border-secondary-600 border divide-y divide-secondary-500">
-                <div className="flex-1 p-4 whitespace-nowrap col-span-2">
+            <div className="rounded-md w-full grid grid-cols-1 sm:grid-cols-8 text-primary-text bg-secondary-700 shadow-lg relative border-secondary-600 border divide-y divide-secondary-500">
+                <div className="flex-1 p-4 whitespace-nowrap sm:col-span-2">
                     <div className="text-base font-normal text-socket-secondary">Asset</div>
                     <div className="flex items-center">
                         <span className="text-sm lg:text-base font-medium text-socket-table text-white flex items-center">
@@ -24,14 +24,14 @@ export default function Refund({ refund }: { refund: Transaction }) {
                         </span>
                     </div>
                 </div>
-                <div className="flex-1 p-4 border-secondary-600 border-l col-span-2">
+                <div className="flex-1 p-4 border-secondary-600 sm:border-l sm:col-span-2">
                     <div className="text-base font-normal text-socket-secondary">Network</div>
                     <div className="flex items-center">
                         <Image alt="Source chain icon" src={network?.logo || ''} width={20} height={20} decoding="async" data-nimg="responsive" className="rounded-md mr-2" />
                         <span className="text-sm lg:text-base font-medium text-socket-table text-white">{network?.display_name}</span>
                     </div>
                 </div>
-                <div className="flex flex-col p-4 border-secondary-600 border-l col-span-4">
+                <div className="flex flex-col p-4 border-secondary-600 sm:border-l sm:col-span-4">
                     <div className="text-base font-normal text-socket-secondary">Transaction</div>
                     <div className="text-sm lg:text-base font-medium text-tx-base w-full">
                         <div className="flex justify-between items-center text-white">


### PR DESCRIPTION
## Summary
- **Header (Completed & non-Completed statuses)**: Status badge displays on its own line on mobile, with date/duration/cost details on the next line. Pipe separators are hidden below the `sm` breakpoint. Each label+value pair (e.g. "Cost: 0.542761 USDC") is wrapped in `whitespace-nowrap` so they never split mid-item.
- **Refund section**: Grid switches from single-column layout on mobile to 8-column on `sm`+. Left borders and col-spans are gated behind the `sm` breakpoint so items stack cleanly on narrow screens.

## Test plan
- [ ] View a **Refunded** swap on mobile (e.g. `0x01885c930c698370b82f2614692eab5305e3d493238eb9750c88f80e172d0884`)
- [ ] View a **Completed** swap on mobile — verify badge on line 1, Date/Duration/Cost on line 2 with no mid-item breaks
- [ ] Verify desktop layout is unchanged (all items on one line with pipe separators)
- [ ] Check Refund section stacks vertically on mobile and displays horizontally on desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)